### PR TITLE
OmniClock: add missing handling for SET_TIME intent

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -138,6 +138,10 @@
                 <action android:name="org.omnirom.deskclock.ACTION_SHOW_STOPWATCH" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SET_TIMER" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
 
         <activity-alias


### PR DESCRIPTION
to make timer actions work with e.g. assistant or google now
was already in HandleApiCalls but somehow lost in manifest

Change-Id: I09f87d5f862f834fd75754ca8dc061c427d0df5b